### PR TITLE
Backfill missing lab metadata (6 files)

### DIFF
--- a/Instructions/Labs/01-create-workspace.md
+++ b/Instructions/Labs/01-create-workspace.md
@@ -1,7 +1,17 @@
 ---
 lab:
-    title: 'Lab: Create an Azure Machine Learning workspace and assets with the CLI (v2)'
-    module: 'Module: Create Azure Machine Learning resources with the CLI (v2)'
+  title: 'Lab: Create an Azure Machine Learning workspace and assets with the CLI
+    (v2)'
+  module: 'Module: Create Azure Machine Learning resources with the CLI (v2)'
+  description: In this exercise, you will create and explore an Azure Machine Learning
+    workspace using the Azure Cloud Shell.
+  duration: 5 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Cloud Shell
+  - Azure Machine Learning
 ---
 
 # Create an Azure Machine Learning workspace and assets with the CLI (v2)

--- a/Instructions/Labs/02-run-python-job.md
+++ b/Instructions/Labs/02-run-python-job.md
@@ -1,7 +1,17 @@
 ---
 lab:
-    title: 'Lab: Run a basic Python training job'
-    module: 'Module: Run jobs in Azure Machine Learning with CLI (v2)'
+  title: 'Lab: Run a basic Python training job'
+  module: 'Module: Run jobs in Azure Machine Learning with CLI (v2)'
+  description: In this exercise, you will train a model with a Python script. The
+    model training will be submitted with the CLI (v2). First, you'll train a model
+    based on a local CSV dataset. Next, you'll train a model using a dataset registered
+    in the Azure Machine Learning workspace.
+  duration: 50 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Machine Learning
 ---
 
 # Run a basic Python training job

--- a/Instructions/Labs/03-run-sweep-job.md
+++ b/Instructions/Labs/03-run-sweep-job.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab: Perform hyperparameter tuning with a sweep job'
-    module: 'Module: Run jobs in Azure Machine Learning with CLI (v2)'
+  title: 'Lab: Perform hyperparameter tuning with a sweep job'
+  module: 'Module: Run jobs in Azure Machine Learning with CLI (v2)'
+  description: In this exercise, you will perform hyperparameter tuning when training
+    a model with a Python script.The model training will be submitted with the CLI
+    (v2).
+  duration: 34 minutes
+  level: 100
+  islab: true
 ---
 
 # Run a sweep job to tune hyperparameters

--- a/Instructions/Labs/04-use-mlflow-jobs.md
+++ b/Instructions/Labs/04-use-mlflow-jobs.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Lab: Track Azure ML jobs with MLflow'
-    module: 'Module: Use MLflow with Azure ML jobs submitted with CLI (v2)'
+  title: 'Lab: Track Azure ML jobs with MLflow'
+  module: 'Module: Use MLflow with Azure ML jobs submitted with CLI (v2)'
+  description: In this exercise, you will train a model with a Python script. The
+    Python script uses **MLflow** to track parameters, metrics, and artifacts.
+  duration: 54 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Azure
 ---
 
 # Track Azure ML jobs with MLflow

--- a/Instructions/Labs/05-deploy-managed-endpoint.md
+++ b/Instructions/Labs/05-deploy-managed-endpoint.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab: Deploy an MLflow model to a managed online endpoint'
-    module: 'Module: Deploy an Azure Machine Learning model to a managed endpoint with CLI (v2)'
+  title: 'Lab: Deploy an MLflow model to a managed online endpoint'
+  module: 'Module: Deploy an Azure Machine Learning model to a managed endpoint with
+    CLI (v2)'
+  description: In this exercise, you will deploy an MLflow model to a managed online
+    endpoint.
+  duration: 42 minutes
+  level: 200
+  islab: true
 ---
 
 # Deploy a model to a managed online endpoint

--- a/Instructions/Labs/06-create-pipeline.md
+++ b/Instructions/Labs/06-create-pipeline.md
@@ -1,7 +1,19 @@
 ---
 lab:
-    title: 'Lab: Run a pipeline with components'
-    module: 'Module: Run component-based pipelines in Azure Machine Learning with CLI (v2)'
+  title: 'Lab: Run a pipeline with components'
+  module: 'Module: Run component-based pipelines in Azure Machine Learning with CLI
+    (v2)'
+  description: In this exercise, you will build a pipeline with components. The pipeline
+    will be submitted with the CLI (v2). First, you'll run a pipeline. Next, you'll
+    create components in the Azure Machine Learning workspace so that they can be
+    reused. Finally, you'll create a pipeline with the Designer in the Azure Machine
+    Learning Studio to experience how you can reuse components to create new pipelines.
+  duration: 80 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Machine Learning
 ---
 
 # Run a pipeline with components


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 6

- `Instructions/Labs/01-create-workspace.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/02-run-python-job.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/03-run-sweep-job.md` (description,duration,level,islab)
- `Instructions/Labs/04-use-mlflow-jobs.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/05-deploy-managed-endpoint.md` (description,duration,level,islab)
- `Instructions/Labs/06-create-pipeline.md` (description,duration,level,islab,primarytopics)
